### PR TITLE
Change name of access log cloudwatch group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 resource "aws_api_gateway_rest_api" "this" {
-  name = "${var.name_prefix}-${var.application_name}"
+  name = "${var.application_name}"
   body = var.schema
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "name_prefix" {
-  description = "A prefix for all resources"
-  type        = string
-}
-
 variable "application_name" {
   description = "The name of the application"
   type        = string


### PR DESCRIPTION
Mange andre ressurser i de nye modulene går vekk fra prefiksen med team-navn. Skal vi kutte det her også?