### PR TITLE
Add option to enable/disable API Gateway metrics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,3 +56,14 @@ resource "aws_cloudwatch_log_group" "api_gateway_access_log" {
   retention_in_days = var.access_log_retention_in_days
 }
 
+resource "aws_api_gateway_method_settings" "this" {
+  count = var.enable_metrics ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  stage_name  = aws_api_gateway_stage.this.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled = true
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,32 +10,38 @@ variable "schema" {
 
 variable "domain_name" {
   description = "The domain name to associate the API Gateway with"
-  type = string
+  type        = string
 }
 
 variable "base_path" {
   description = "The base path of the API Gateway"
-  type = string
+  type        = string
 }
 
 variable "stage_name" {
   description = "The name of the API Stage"
-  type = string
+  type        = string
 
   default = "v1"
 }
 
 variable "enable_xray" {
   description = "Use AWS XRay with this API Gateway?"
-  type = bool
+  type        = bool
 
   default = false
 }
 
 variable "access_log_retention_in_days" {
   description = "Amount of days to keep the access logs"
-  type = number
+  type        = number
 
   default = 14
 }
 
+variable "enable_metrics" {
+  description = "Enable metrics for the API Gateway"
+  type        = bool
+
+  default = false
+}


### PR DESCRIPTION
Setter default til false selv om jeg synes dette er nice. Skjermbilde av prisingen under (eksempel 30 [her](https://aws.amazon.com/cloudwatch/pricing/))
![image](https://github.com/user-attachments/assets/d0671da4-3fda-4702-b667-187a317252fc)
